### PR TITLE
Feature: InjectiveStaking add new compound_rewards function

### DIFF
--- a/injective_functions/function_schemas.json
+++ b/injective_functions/function_schemas.json
@@ -103,6 +103,20 @@
         }
       },
       {
+        "name": "compound_rewards",
+        "description": "Automatically reinvest your staking rewards with a specific validator to increase your staked amount.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "validator_address": {
+              "type": "string",
+              "description": "Validator address you want to compound your rewards with."
+            }
+          },
+          "required": ["validator_address"]
+        }
+      },
+      {
         "name": "transfer_funds",
         "description": "Transfer funds to another Injective address",
         "parameters": {

--- a/injective_functions/functions_schemas.json
+++ b/injective_functions/functions_schemas.json
@@ -779,6 +779,20 @@
       }
     },
     {
+      "name": "compound_rewards",
+      "description": "Automatically reinvest your staking rewards with a specific validator to increase your staked amount.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "validator_address": {
+            "type": "string",
+            "description": "Validator address you want to compound your rewards with."
+          }
+        },
+        "required": ["validator_address"]
+      }
+    },
+    {
       "name": "create_denom",
       "description": "Create a new token denomination",
       "parameters": {

--- a/injective_functions/staking/__init__.py
+++ b/injective_functions/staking/__init__.py
@@ -1,6 +1,7 @@
+import asyncio
 from decimal import Decimal
 from injective_functions.base import InjectiveBase
-from typing import Dict, List
+from typing import Dict
 
 
 """This class handles all account transfer within the account"""
@@ -19,3 +20,83 @@ class InjectiveStaking(InjectiveBase):
             amount=float(amount),
         )
         return await self.chain_client.build_and_broadcast_tx(msg)
+
+    async def compound_rewards(self, validator_address: str) -> Dict:
+        """
+        Compounds staking rewards by withdrawing them and restaking.
+        :param validator_address: The validator's address
+        :return: Transaction result
+        """
+        try:
+            # Step 1: Fetch the initial INJ balance
+            balance_response = await self.chain_client.client.get_bank_balance(
+                address=self.chain_client.address.to_acc_bech32(),
+                denom="inj"
+            )
+            initial_balance = Decimal(balance_response.balance.amount)
+
+            # Step 2: Withdraw rewards
+            withdraw_msg = self.chain_client.composer.msg_withdraw_delegator_reward(
+                delegator_address=self.chain_client.address.to_acc_bech32(),
+                validator_address=validator_address,
+            )
+            withdraw_response = await self.chain_client.build_and_broadcast_tx(withdraw_msg)
+
+            # Step 3: Wait for the balance to update
+            updated_balance = await self.wait_for_balance_update(old_balance=initial_balance, denom="inj")
+
+            # Step 4: Calculate the withdrawn rewards
+            rewards_to_stake = updated_balance - initial_balance
+            if rewards_to_stake <= 0:
+                if rewards_to_stake < 0:
+                    # Specific error for negative rewards
+                    return {
+                        "success": False,
+                        "error": f"Rewards ({rewards_to_stake}) are lower than gas fees, resulting in a negative net "
+                                 f"reward."
+                    }
+                # Generic error for zero rewards
+                return {"success": False, "error": "No rewards available to compound."}
+
+            # Step 5: Restake the rewards
+            delegate_msg = self.chain_client.composer.MsgDelegate(
+                delegator_address=self.chain_client.address.to_acc_bech32(),
+                validator_address=validator_address,
+                amount=float(rewards_to_stake) / (10 ** 18),
+            )
+            delegate_response = await self.chain_client.build_and_broadcast_tx(delegate_msg)
+
+            return {
+                "success": True,
+                "withdraw_response": withdraw_response,
+                "delegate_response": delegate_response,
+            }
+
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def wait_for_balance_update(
+        self,
+        old_balance: Decimal,
+        denom: str,
+        timeout: int = 10,
+        interval: int = 1
+    ) -> Decimal:
+        """
+        Waits for the balance to update after a transaction.
+        :param old_balance: Previous balance to compare against
+        :param denom: Denomination of the token (e.g., "inj")
+        :param timeout: Total time to wait (in seconds)
+        :param interval: Time between balance checks (in seconds)
+        :return: Updated balance
+        """
+        for _ in range(timeout // interval):
+            balance_response = await self.chain_client.client.get_bank_balance(
+                address=self.chain_client.address.to_acc_bech32(),
+                denom=denom
+            )
+            updated_balance = Decimal(balance_response.balance.amount)
+            if updated_balance != old_balance:
+                return updated_balance
+            await asyncio.sleep(interval)
+        raise TimeoutError("Balance did not update within the timeout period.")

--- a/injective_functions/staking/staking_schema.json
+++ b/injective_functions/staking/staking_schema.json
@@ -17,6 +17,20 @@
           },
           "required": ["validator_address", "amount"]
         }
+      },
+      {
+        "name": "compound_rewards",
+        "description": "Automatically reinvest your staking rewards with a specific validator to increase your staked amount.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "validator_address": {
+              "type": "string",
+              "description": "Validator address you want to compound your rewards with."
+            }
+          },
+          "required": ["validator_address"]
+        }
       }
     ]
   }

--- a/injective_functions/utils/function_helper.py
+++ b/injective_functions/utils/function_helper.py
@@ -45,6 +45,7 @@ class InjectiveFunctionMapper:
         "query_total_supply": ("bank", "query_total_supply"),
         # Staking functions
         "stake_tokens": ("staking", "stake_tokens"),
+        "compound_rewards": ("staking", "compound_rewards"),
         # Auction functions
         "send_bid_auction": ("auction", "send_bid_auction"),
         # Authz functions


### PR DESCRIPTION
This pull request introduces a new feature to the `InjectiveStaking` module: the `compound_rewards` function. This function enables users to withdraw staking rewards from a validator and automatically re-stake them, compounding the rewards to maximize staking benefits.

---

## Key Changes
### 1. New Functionality:
- **`compound_rewards(validator_address: str)`**
  - Automates:
    - Fetching the current balance.
    - Withdrawing staking rewards.
    - Calculating available rewards after fees.
    - Re-delegating the rewards back to the validator.

### 2. Error Handling:
- Introduced specific error messages for scenarios:
  - No rewards are available for compounding.
  - Rewards are insufficient to cover gas fees.
  - General errors with detailed exceptions.

### 3. Optimizations:
- Added a utility function `wait_for_balance_update` to ensure updated balance information after withdrawals.

---

## How to Test
1. Ensure the agent has staked INJ with a validator and accumulated sufficient rewards.
2. Call the `compound_rewards` function with a valid `validator_address`.
3. Validate the following scenarios:
   - Successful reward compounding.
   - Handling of insufficient rewards (reward balance lower than gas fees).
   - Handling of cases where no rewards are available.

---

## Benefits
- Automates reward compounding, reducing manual steps.
- Improves user experience by handling edge cases and errors gracefully.
- Provides a scalable foundation for further staking-related enhancements.

---

## Notes
- Ensure your wallet has sufficient funds to cover gas fees for both withdrawal and delegation transactions.
- This feature relies on accurate balance updates after withdrawal; any delays might require revisiting the `wait_for_balance_update` implementation.

---

## Checklist
- [x] Added `compound_rewards` function.
- [x] Implemented error handling for edge cases.
- [x] Tested for common and edge scenarios.
- [x] Updated documentation for the new functionality.

---

Feel free to suggest improvements or additional scenarios to test!