### PR TITLE
Add snapshot module to create an airdrop

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -5,6 +5,7 @@ from quart import Quart, request, jsonify
 from datetime import datetime
 import argparse
 from injective_functions.factory import InjectiveClientFactory
+from injective_functions.snapshot import Snapshot
 from injective_functions.utils.function_helper import (
     FunctionSchemaLoader,
     FunctionExecutor,
@@ -46,6 +47,7 @@ class InjectiveChatAgent:
             "./injective_functions/exchange/exchange_schema.json",
             "./injective_functions/staking/staking_schema.json",
             "./injective_functions/token_factory/token_factory_schema.json",
+            "./injective_functions/snapshot/snapshot_schema.json",
             "./injective_functions/utils/utils_schema.json",
         ]
         self.function_schemas = FunctionSchemaLoader.load_schemas(schema_paths)

--- a/injective_functions/factory.py
+++ b/injective_functions/factory.py
@@ -8,6 +8,7 @@ from injective_functions.exchange.exchange import InjectiveExchange
 from injective_functions.exchange.trader import InjectiveTrading
 from injective_functions.staking import InjectiveStaking
 from injective_functions.token_factory import InjectiveTokenFactory
+from injective_functions.snapshot import Snapshot
 
 
 class InjectiveClientFactory:
@@ -41,6 +42,7 @@ class InjectiveClientFactory:
             "trader": InjectiveTrading(chain_client),
             "staking": InjectiveStaking(chain_client),
             "token_factory": InjectiveTokenFactory(chain_client),
+            "snapshot": Snapshot(),
         }
         print(clients)
         return clients

--- a/injective_functions/function_schemas.json
+++ b/injective_functions/function_schemas.json
@@ -124,6 +124,15 @@
           },
           "required": ["to_address", "amount"]
         }
+      },
+      {
+        "name": "get_snapshot",
+        "description": "Get a snapshot to create an airdrop",
+        "parameters": {
+          "type": "object",
+          "properties": {},
+          "required": []
+        }
       }
     ]
   }

--- a/injective_functions/functions_schemas.json
+++ b/injective_functions/functions_schemas.json
@@ -906,6 +906,15 @@
           "uri_hash"
         ]
       }
+    },
+    {
+      "name": "get_snapshot",
+      "description": "Get a snapshot to create an airdrop",
+      "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
     }
   ]
 }

--- a/injective_functions/snapshot/__init__.py
+++ b/injective_functions/snapshot/__init__.py
@@ -1,0 +1,17 @@
+import json
+from typing import Dict, List
+import requests
+
+"""This class handles all the functions related to the snapshot module"""
+
+
+class Snapshot():
+    def __init__(self) -> None:
+        # Initializes the network and the composer
+        super().__init__()
+
+    async def get_snapshot(self) -> List[Dict]:
+        data = requests.get(
+            "https://tokenstation.app/api/snapshots/last").json()
+
+        return data

--- a/injective_functions/snapshot/snapshot_schema.json
+++ b/injective_functions/snapshot/snapshot_schema.json
@@ -1,0 +1,13 @@
+{
+  "functions": [
+    {
+      "name": "get_snapshot",
+      "description": "Get a snapshot to create an airdrop",
+      "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    }
+  ]
+}

--- a/injective_functions/utils/function_helper.py
+++ b/injective_functions/utils/function_helper.py
@@ -56,6 +56,8 @@ class InjectiveFunctionMapper:
         "mint": ("token_factory", "mint"),
         "burn": ("token_factory", "burn"),
         "set_denom_metadata": ("token_factory", "set_denom_metadata"),
+
+        "get_snapshot": ("snapshot", "get_snapshot"),
     }
 
     @classmethod


### PR DESCRIPTION
Add a snapshot module to create an airdrop


![telegram-cloud-photo-size-2-5370777520871434782-y](https://github.com/user-attachments/assets/47b3f395-9486-454a-bf52-9e10796f82b6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new function `get_snapshot` to retrieve snapshots for airdrop creation.
	- Added a new `Snapshot` class to handle snapshot-related functions, including an asynchronous method for data retrieval.

- **Improvements**
	- Expanded the `InjectiveChatAgent` to support snapshot-related schema.
	- Updated the `InjectiveClientFactory` to include the `Snapshot` client.

- **Documentation**
	- New schema file for the snapshot function has been added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->